### PR TITLE
fix: remove redundant yarn install from storefront service command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,6 @@ services:
       - medusa
     ports:
       - "8000:8000"
-    command: ["sh", "-lc", "yarn install && yarn dev -H 0.0.0.0"]
     env_file:
       - ./.env
     environment:


### PR DESCRIPTION
## Summary

Remove redundant `yarn install` command from the storefront service in docker-compose.yml. The storefront Dockerfile already installs dependencies during the build phase, making the command override unnecessary and causing slower container startup times.

## Changes
- [ ] Backend
- [x] Storefront
  - Removed `command` override from storefront service in docker-compose.yml
  - Container now uses the Dockerfile's CMD which runs `yarn dev` directly
  - Dependencies are pre-installed during image build instead of on every container start

## Testing

1. Ensure you have the latest changes: `git checkout fix/storefront-yarn-install`
2. Build and start the stack: `docker compose up --build`
3. Verify storefront starts faster (no "yarn install" output in logs)
4. Confirm storefront is accessible at http://localhost:8000
5. Check that hot reload still works when editing storefront files

## Screenshots

No visual changes - this is a performance optimization.